### PR TITLE
simple-whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ foundryup
 3. Install external libs
 
 ```bash
-git submodule update --init
+git submodule update --init && foundry update
 ```
+
+If git modules are failing to clone, not installing, etc (ie overall submodule misbehaving), use `git submodule update --init --recursive --force`
 
 Resources:
 

--- a/contracts/DatasourceDelegate/examples/whitelist/WhitelistDataSource.sol
+++ b/contracts/DatasourceDelegate/examples/whitelist/WhitelistDataSource.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import '@jbx-protocol-v2/contracts/interfaces/IJBFundingCycleDataSource.sol';
+import '@jbx-protocol-v2/contracts/interfaces/IJBProjects.sol';
+
+/**
+  @title
+  Juicebox Datasource for simple whitelisting
+
+  @notice
+  This is a datasource handeling a mapping of whitelisted addresses. The project owner should add
+  addresses to this datasource using addToWhitelist. This is a simple imlpementation (using a mapping),
+  for bigger whitelist, a more gas-efficient solution might be better (eg merkle tree)
+
+  @dev
+  Access is controlled at add/remove whitelist addresses level, the delegate can be reused if another
+  project wants the same set of whitelisted addresses.
+*/
+contract WhitelistDataSource is IJBFundingCycleDataSource {
+  IJBProjects immutable jbProjects;
+
+  uint256 immutable projectId;
+
+  /**
+    @dev Throws if a non-whitelisted beneficiary trie to pay
+  */
+  error WhitelistDataSource_BeneficiaryNotWhitelisted();
+
+  /**
+    @dev   emit when adding addresses to the whitelist
+    @param numberOfAddresses the number of addresses, if an array was passed
+  */
+  event AddToWhitelist(uint256 numberOfAddresses);
+
+  /**
+    @dev   emit when removing addresses to the whitelist
+    @param numberOfAddresses the number of addresses, if an array was passed
+  */
+  event RemoveFromWhitelist(uint256 numberOfAddresses);
+
+  /**
+    @notice the whitelisted addresses, true if whitelisted
+  */
+  mapping(address => bool) public isWhitelisted;
+
+  /**
+    @notice Only the holder of the project NFT can execute the function (used for the whitelist management)
+  */
+  modifier onlyProjectOwner(uint256 _projectId) {
+    if (msg.sender != jbProjects.ownerOf(_projectId)) revert WhitelistDataSource_Unauthorised();
+    _;
+  }
+
+  /**
+    @param _jbProjects the JBProjects contracts deployment
+    @param _projectId the id of the project (the holder of the corresponding NFT has access to add/remove address)
+  */
+  constructor(IJBProjects _jbProjects, uint256 _projectId) {
+    jbProjects = _jbProjects;
+    projectId = _projectId;
+  }
+
+  //@inheritdocs IJBFundingCycleDataSource
+  function payParams(JBPayParamsData calldata _data)
+    external
+    view
+    override
+    returns (
+      uint256 weight,
+      string memory memo,
+      IJBPayDelegate delegate
+    )
+  {
+    // Revert if beneficiary is non whitelisted
+    if (!isWhitelisted[_data.beneficiary]) revert WhitelistDataSource_BeneficiaryNotWhitelisted();
+
+    // If disabling non-whitelisted payer too, uncomment the following:
+    // if (!isWhitelisted[_data.payer]) revert WhitelistDataSource_BeneficiaryNotWhitelisted();
+
+    return (_data.weight, _data.memo, IJBPayDelegate(address(0)));
+  }
+
+  /**
+    @notice  Add an array of addresses to the whitelist
+    @dev     the previous whitelist status is not read, for gas optimisation
+    @param   addresses the addresses to whitelist
+  */
+  function addToWhitelist(address[] calldata addresses) onlyProjectOwner {
+    uint256 numberOfAddresses = addresses.length; // Push to stack
+    for (uint256 i; i < numberOfAddresses; ) {
+      isWhitelisted[addresses[i]] = true;
+      unchecked {
+        ++i;
+      }
+    }
+    emit AddToWhitelist(numberOfAddresses); // Not passing the whole array for gas reason
+  }
+
+  /**
+    @notice  Add a single address to the whitelist
+    @param   _address the address to whitelist
+  */
+  function addToWhitelist(address _address) onlyProjectOwner {
+    isWhitelisted[_address] = true;
+    emit AddToWhitelist(1);
+  }
+
+  /**
+    @notice  Remove an array of addresses from the whitelist
+    @dev     the previous whitelist status is not read, for gas optimisation
+    @param   addresses the addresses to remove from the whitelist
+  */
+  function removeFromWhitelist(address[] calldata addresses) external onlyProjectOwner {
+    uint256 numberOfAddresses = addresses.length; // Push to stack
+    for (uint256 i; i < numberOfAddresses; ) {
+      delete isWhitelisted[addresses[i]];
+      unchecked {
+        ++i;
+      }
+    }
+    emit RemoveFromWhitelist(numberOfAddresses);
+  }
+
+  /**
+    @notice  Remove a single address from the whitelist
+    @dev     the previous whitelist status is not read, for gas optimisation
+    @param   _address the addresses to remove from the whitelist
+  */
+  function removeFromWhitelist(address _address) external onlyProjectOwner {
+    delete isWhitelisted[_address];
+    emit RemoveFromWhitelist(1);
+  }
+
+  function supportsInterface(bytes4 _interfaceId) external pure override returns (bool) {
+    return _interfaceId == type(IJBFundingCycleDataSource).interfaceId;
+  }
+
+  //@dev unused, for interface completion only
+  //@inheritdocs IJBFundingCycleDataSource
+  function redeemParams(JBRedeemParamsData calldata _data)
+    external
+    view
+    override
+    returns (
+      uint256 reclaimAmount,
+      string memory memo,
+      IJBRedemptionDelegate delegate
+    )
+  {
+    return (_data.reclaimAmount.value, _data.memo, IJBRedemptionDelegate(address(0)));
+  }
+}

--- a/contracts/DatasourceDelegate/examples/whitelist/WhitelistDataSource.sol
+++ b/contracts/DatasourceDelegate/examples/whitelist/WhitelistDataSource.sol
@@ -80,7 +80,7 @@ contract WhitelistDataSource is IJBFundingCycleDataSource {
     // Revert if beneficiary is non whitelisted
     if (!isWhitelisted[_data.beneficiary]) revert WhitelistDataSource_BeneficiaryNotWhitelisted();
 
-    // If disabling non-whitelisted payer too, uncomment the following:
+    // If disabling non-whitelisted payers too, uncomment the following:
     // if (!isWhitelisted[_data.payer]) revert WhitelistDataSource_BeneficiaryNotWhitelisted();
 
     return (_data.weight, _data.memo, IJBPayDelegate(address(0)));

--- a/contracts/DatasourceDelegate/test/TestNFT.sol
+++ b/contracts/DatasourceDelegate/test/TestNFT.sol
@@ -101,8 +101,8 @@ contract TestNFT is TestBaseWorkflow {
   /// @notice will test the NFT minting triggered by a call to pay()
   function testMint() public {
     address caller = address(69420);
-    evm.startPrank(caller);
-    evm.deal(caller, 100 ether);
+    vm.startPrank(caller);
+    vm.deal(caller, 100 ether);
 
     _terminal.pay{value: 20 ether}(
       _projectId,
@@ -124,8 +124,8 @@ contract TestNFT is TestBaseWorkflow {
     address callerTwo = address(42069);
 
     // pay to the project, caller One will then receive the NFT (via the pay delegate)
-    evm.startPrank(callerOne);
-    evm.deal(callerOne, 100 ether);
+    vm.startPrank(callerOne);
+    vm.deal(callerOne, 100 ether);
 
     _terminal.pay{value: 20 ether}(
       _projectId,
@@ -157,8 +157,8 @@ contract TestNFT is TestBaseWorkflow {
 
     uint256 transferedCallerOne = callerOne.balance - balanceBeforeCallerOne;
 
-    evm.stopPrank();
-    evm.startPrank(callerTwo);
+    vm.stopPrank();
+    vm.startPrank(callerTwo);
     uint256 balanceBeforeCallerTwo = callerTwo.balance;
 
     _terminal.redeemTokensOf(

--- a/contracts/DatasourceDelegate/test/TestWhitelist.sol
+++ b/contracts/DatasourceDelegate/test/TestWhitelist.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.6;
 
 import './helpers/TestBaseWorkflow.sol';
-import '../examples/whitelist/WhitelistDatasource.sol';
+import '../examples/whitelist/WhitelistDataSource.sol';
 
 import '@jbx-protocol-v2/contracts/interfaces/IJBFundingCycleDataSource.sol';
 

--- a/contracts/DatasourceDelegate/test/TestWhitelist.sol
+++ b/contracts/DatasourceDelegate/test/TestWhitelist.sol
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import './helpers/TestBaseWorkflow.sol';
+import '../examples/whitelist/WhitelistDatasource.sol';
+
+import '@jbx-protocol-v2/contracts/interfaces/IJBFundingCycleDataSource.sol';
+
+contract TestWhitelist is TestBaseWorkflow {
+  JBController private _controller;
+  JBETHPaymentTerminal private _terminal;
+  JBTokenStore private _tokenStore;
+
+  JBProjectMetadata private _projectMetadata;
+  JBFundingCycleData private _data;
+  JBFundingCycleMetadata private _metadata;
+  JBGroupedSplits[] private _groupedSplits; // Default empty
+  JBFundAccessConstraints[] private _fundAccessConstraints; // Default empty
+  IJBPaymentTerminal[] private _terminals; // Default empty
+
+  uint256 private _projectId;
+  address private _projectOwner;
+  uint256 private _weight = 1000 * 10**18;
+  uint256 private _targetInWei = 10 * 10**18;
+
+  WhitelistDataSource whitelistDatasource;
+
+  event AddToWhitelist(uint256 numberOfAddresses);
+  event RemoveFromWhitelist(uint256 numberOfAddresses);
+
+  function setUp() public override {
+    super.setUp();
+
+    whitelistDatasource = new WhitelistDataSource(jbProjects(), 1); /*projectid jbproject*/
+
+    _controller = jbController();
+
+    _terminal = jbETHPaymentTerminal();
+
+    _tokenStore = jbTokenStore();
+
+    _projectMetadata = JBProjectMetadata({content: 'myIPFSHash', domain: 1});
+
+    _data = JBFundingCycleData({
+      duration: 14,
+      weight: _weight,
+      discountRate: 450000000,
+      ballot: IJBFundingCycleBallot(address(0))
+    });
+
+    _metadata = JBFundingCycleMetadata({
+      global: JBGlobalFundingCycleMetadata({allowSetTerminals: false, allowSetController: false}),
+      reservedRate: 0,
+      redemptionRate: 10000, //100%
+      ballotRedemptionRate: 0,
+      pausePay: false,
+      pauseDistributions: false,
+      pauseRedeem: false,
+      pauseBurn: false,
+      allowMinting: false,
+      allowChangeToken: false,
+      allowTerminalMigration: false,
+      allowControllerMigration: false,
+      holdFees: false,
+      useTotalOverflowForRedemptions: false,
+      useDataSourceForPay: true,
+      useDataSourceForRedeem: true,
+      dataSource: address(whitelistDatasource)
+    });
+
+    _terminals.push(_terminal);
+
+    _fundAccessConstraints.push(
+      JBFundAccessConstraints({
+        terminal: _terminal,
+        token: jbLibraries().ETHToken(),
+        distributionLimit: _targetInWei, // 10 ETH target
+        overflowAllowance: 5 ether,
+        distributionLimitCurrency: 1, // Currency = ETH
+        overflowAllowanceCurrency: 1
+      })
+    );
+
+    _projectOwner = multisig();
+
+    _projectId = _controller.launchProjectFor(
+      _projectOwner,
+      _projectMetadata,
+      _data,
+      _metadata,
+      block.timestamp,
+      _groupedSplits,
+      _fundAccessConstraints,
+      _terminals,
+      ''
+    );
+  }
+
+  // -- AddToWhitelist --
+
+  function testAddToWhitelist_addOneAddressIfCallerIsProjectOwner(
+    address _whitelistedAddress,
+    address _nonWhitelistedAddress
+  ) external {
+    vm.assume(_whitelistedAddress != _nonWhitelistedAddress);
+    vm.prank(_projectOwner);
+
+    // Emit correct event?
+    vm.expectEmit(false, false, false, true);
+    emit AddToWhitelist(1);
+
+    whitelistDatasource.addToWhitelist(_whitelistedAddress);
+
+    // Check: is whitelisted and a non-whitelisted isn't, by default
+    assertEq(whitelistDatasource.isWhitelisted(_whitelistedAddress), true);
+    assertEq(whitelistDatasource.isWhitelisted(_nonWhitelistedAddress), false);
+  }
+
+  function testAddToWhitelist_addMultipleAddressesIfCallerIsProjectOwner(uint8 numberOfAddresses)
+    external
+  {
+    vm.assume(numberOfAddresses < 200);
+    address[] memory _addressesToAdd = new address[](numberOfAddresses);
+    for (uint256 i; i < numberOfAddresses; i++)
+      _addressesToAdd[i] = address(bytes20(keccak256(abi.encode(i))));
+
+    vm.prank(_projectOwner);
+
+    // Emit correct event?
+    vm.expectEmit(false, false, false, true);
+    emit AddToWhitelist(numberOfAddresses);
+
+    whitelistDatasource.addToWhitelist(_addressesToAdd);
+
+    // Check: all the addresses are now whitelisted
+    for (uint256 i; i < numberOfAddresses; i++)
+      assertEq(whitelistDatasource.isWhitelisted(_addressesToAdd[i]), true);
+  }
+
+  function testAddToWhitelist_revertIfCallerIsNotProjectOwner(
+    address _whitelistedAddress,
+    address _caller
+  ) external {
+    vm.assume(_caller != _projectOwner);
+    vm.prank(_caller);
+
+    vm.expectRevert(abi.encodeWithSignature('WhitelistDataSource_Unauthorised()'));
+    whitelistDatasource.addToWhitelist(_whitelistedAddress);
+
+    // Check: still not whitelisted
+    assertEq(whitelistDatasource.isWhitelisted(_whitelistedAddress), false);
+  }
+
+  // -- removeFromWhitelist --
+
+  function testRemoveFromWhitelist_removeOneAddressIfCallerIsProjectOwner(
+    address _whitelistedAddress
+  ) external {
+    vm.prank(_projectOwner);
+    whitelistDatasource.addToWhitelist(_whitelistedAddress);
+
+    // Sqnity check
+    assertEq(whitelistDatasource.isWhitelisted(_whitelistedAddress), true);
+
+    // Emit correct event?
+    vm.expectEmit(false, false, false, true);
+    emit RemoveFromWhitelist(1);
+
+    vm.prank(_projectOwner);
+    whitelistDatasource.removeFromWhitelist(_whitelistedAddress);
+
+    // Check: is whitelisted and a non-whitelisted isn't, by default
+    assertEq(whitelistDatasource.isWhitelisted(_whitelistedAddress), false);
+  }
+
+  function testRemoveFromWhitelist_removeMultipleAddressesIfCallerIsProjectOwner(
+    uint8 numberOfAddresses
+  ) external {
+    // Set the addresses
+    vm.assume(numberOfAddresses < 200);
+    address[] memory _addressesToAdd = new address[](numberOfAddresses);
+    for (uint256 i; i < numberOfAddresses; i++)
+      _addressesToAdd[i] = address(bytes20(keccak256(abi.encode(i))));
+
+    vm.prank(_projectOwner);
+    whitelistDatasource.addToWhitelist(_addressesToAdd);
+
+    // Sanity check: all the addresses are now whitelisted
+    for (uint256 i; i < numberOfAddresses; i++)
+      assertEq(whitelistDatasource.isWhitelisted(_addressesToAdd[i]), true);
+
+    // Emit correct event?
+    vm.expectEmit(false, false, false, true);
+    emit RemoveFromWhitelist(numberOfAddresses);
+
+    vm.prank(_projectOwner);
+    whitelistDatasource.removeFromWhitelist(_addressesToAdd);
+
+    // Check: is whitelisted and a non-whitelisted isn't, by default
+    for (uint256 i; i < numberOfAddresses; i++)
+      assertEq(whitelistDatasource.isWhitelisted(_addressesToAdd[i]), false);
+  }
+
+  function testRemoveFromWhitelist_revertIfCallerIsNotProjectOwner(
+    address _caller,
+    address _whitelistedAddress
+  ) external {
+    vm.assume(_caller != _projectOwner);
+
+    vm.prank(_projectOwner);
+    whitelistDatasource.addToWhitelist(_whitelistedAddress);
+
+    // Sanity check
+    assertEq(whitelistDatasource.isWhitelisted(_whitelistedAddress), true);
+
+    vm.prank(_caller);
+    vm.expectRevert(abi.encodeWithSignature('WhitelistDataSource_Unauthorised()'));
+    whitelistDatasource.removeFromWhitelist(_whitelistedAddress);
+
+    assertEq(whitelistDatasource.isWhitelisted(_whitelistedAddress), true);
+  }
+
+  // -- payParams --
+
+  function testPayParams_returnCorrectWeightIfBeneficiaryIsWhitelisted(
+    address _whitelistedAddress,
+    uint256 _whitelistWeight,
+    string memory _whitelistMemo
+  ) external {
+    vm.prank(_projectOwner);
+    whitelistDatasource.addToWhitelist(_whitelistedAddress);
+
+    // Sanity check
+    assertEq(whitelistDatasource.isWhitelisted(_whitelistedAddress), true);
+
+    JBPayParamsData memory _payParamsData = JBPayParamsData({
+      terminal: IJBPaymentTerminal(msg.sender),
+      payer: address(666),
+      amount: JBTokenAmount({token: address(0), value: 10 ether, decimals: 18, currency: 1}),
+      projectId: _projectId,
+      currentFundingCycleConfiguration: block.timestamp,
+      beneficiary: _whitelistedAddress,
+      weight: _whitelistWeight,
+      reservedRate: 0,
+      memo: _whitelistMemo,
+      metadata: new bytes(0)
+    });
+
+    (
+      uint256 _returnedWeight,
+      string memory _returnedMemo,
+      IJBPayDelegate _delegate
+    ) = whitelistDatasource.payParams(_payParamsData);
+
+    assertEq(_returnedWeight, _whitelistWeight);
+    assertEq(_returnedMemo, _whitelistMemo);
+    assertEq(address(_delegate), address(0));
+  }
+
+  function testPayParams_revertIfBeneficiaryIsNotWhitelisted(
+    address _whitelistedAddress,
+    uint256 _whitelistWeight,
+    string memory _whitelistMemo
+  ) external {
+    // Sanity check
+    assertEq(whitelistDatasource.isWhitelisted(_whitelistedAddress), false);
+
+    JBPayParamsData memory _payParamsData = JBPayParamsData({
+      terminal: IJBPaymentTerminal(msg.sender),
+      payer: address(666),
+      amount: JBTokenAmount({token: address(0), value: 10 ether, decimals: 18, currency: 1}),
+      projectId: _projectId,
+      currentFundingCycleConfiguration: block.timestamp,
+      beneficiary: _whitelistedAddress,
+      weight: _whitelistWeight,
+      reservedRate: 0,
+      memo: _whitelistMemo,
+      metadata: new bytes(0)
+    });
+
+    vm.expectRevert(abi.encodeWithSignature('WhitelistDataSource_BeneficiaryNotWhitelisted()'));
+    (
+      uint256 _returnedWeight,
+      string memory _returnedMemo,
+      IJBPayDelegate _delegate
+    ) = whitelistDatasource.payParams(_payParamsData);
+  }
+}

--- a/contracts/DatasourceDelegate/test/helpers/TestBaseWorkflow.sol
+++ b/contracts/DatasourceDelegate/test/helpers/TestBaseWorkflow.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
-import 'ds-test/test.sol';
-import 'forge-std/Vm.sol';
+import 'forge-std/Test.sol';
 
 import '@jbx-protocol-v2/contracts/JBController.sol';
 import '@jbx-protocol-v2/contracts/JBDirectory.sol';
@@ -41,7 +40,7 @@ import '@paulrberg/contracts/math/PRBMath.sol';
 // Base contract for Juicebox system tests.
 //
 // Provides common functionality, such as deploying contracts on test setup.
-contract TestBaseWorkflow is DSTest {
+contract TestBaseWorkflow is Test {
   //*********************************************************************//
   // --------------------- private stored properties ------------------- //
   //*********************************************************************//
@@ -50,9 +49,6 @@ contract TestBaseWorkflow is DSTest {
   address private _multisig = address(123);
 
   address private _beneficiary = address(69420);
-
-  // EVM Cheat codes - test addresses via prank and startPrank in hevm
-  Vm public evm = Vm(HEVM_ADDRESS);
 
   // JBOperatorStore
   JBOperatorStore private _jbOperatorStore;
@@ -152,38 +148,38 @@ contract TestBaseWorkflow is DSTest {
   // Deploys and initializes contracts for testing.
   function setUp() public virtual {
     // Labels
-    evm.label(_multisig, 'projectOwner');
-    evm.label(_beneficiary, 'beneficiary');
+    vm.label(_multisig, 'projectOwner');
+    vm.label(_beneficiary, 'beneficiary');
 
     // JBOperatorStore
     _jbOperatorStore = new JBOperatorStore();
-    evm.label(address(_jbOperatorStore), 'JBOperatorStore');
+    vm.label(address(_jbOperatorStore), 'JBOperatorStore');
 
     // JBProjects
     _jbProjects = new JBProjects(_jbOperatorStore);
-    evm.label(address(_jbProjects), 'JBProjects');
+    vm.label(address(_jbProjects), 'JBProjects');
 
     // JBPrices
     _jbPrices = new JBPrices(_multisig);
-    evm.label(address(_jbPrices), 'JBPrices');
+    vm.label(address(_jbPrices), 'JBPrices');
 
     address contractAtNoncePlusOne = addressFrom(address(this), 5);
 
     // JBFundingCycleStore
     _jbFundingCycleStore = new JBFundingCycleStore(IJBDirectory(contractAtNoncePlusOne));
-    evm.label(address(_jbFundingCycleStore), 'JBFundingCycleStore');
+    vm.label(address(_jbFundingCycleStore), 'JBFundingCycleStore');
 
     // JBDirectory
     _jbDirectory = new JBDirectory(_jbOperatorStore, _jbProjects, _jbFundingCycleStore, _multisig);
-    evm.label(address(_jbDirectory), 'JBDirectory');
+    vm.label(address(_jbDirectory), 'JBDirectory');
 
     // JBTokenStore
     _jbTokenStore = new JBTokenStore(_jbOperatorStore, _jbProjects, _jbDirectory);
-    evm.label(address(_jbTokenStore), 'JBTokenStore');
+    vm.label(address(_jbTokenStore), 'JBTokenStore');
 
     // JBSplitsStore
     _jbSplitsStore = new JBSplitsStore(_jbOperatorStore, _jbProjects, _jbDirectory);
-    evm.label(address(_jbSplitsStore), 'JBSplitsStore');
+    vm.label(address(_jbSplitsStore), 'JBSplitsStore');
 
     // JBController
     _jbController = new JBController(
@@ -194,9 +190,9 @@ contract TestBaseWorkflow is DSTest {
       _jbTokenStore,
       _jbSplitsStore
     );
-    evm.label(address(_jbController), 'JBController');
+    vm.label(address(_jbController), 'JBController');
 
-    evm.prank(_multisig);
+    vm.prank(_multisig);
     _jbDirectory.setIsAllowedToSetFirstController(address(_jbController), true);
 
     // JBETHPaymentTerminalStore
@@ -205,7 +201,7 @@ contract TestBaseWorkflow is DSTest {
       _jbFundingCycleStore,
       _jbPrices
     );
-    evm.label(address(_jbPaymentTerminalStore), 'JBSingleTokenPaymentTerminalStore');
+    vm.label(address(_jbPaymentTerminalStore), 'JBSingleTokenPaymentTerminalStore');
 
     // AccessJBLib
     _accessJBLib = new AccessJBLib();
@@ -221,12 +217,12 @@ contract TestBaseWorkflow is DSTest {
       _jbPaymentTerminalStore,
       _multisig
     );
-    evm.label(address(_jbETHPaymentTerminal), 'JBETHPaymentTerminal');
+    vm.label(address(_jbETHPaymentTerminal), 'JBETHPaymentTerminal');
 
-    evm.prank(_multisig);
+    vm.prank(_multisig);
     _jbToken = new JBToken('MyToken', 'MT');
 
-    evm.prank(_multisig);
+    vm.prank(_multisig);
     _jbToken.mint(0, _multisig, 100 * 10**18);
 
     // JBERC20PaymentTerminal
@@ -243,7 +239,7 @@ contract TestBaseWorkflow is DSTest {
       _jbPaymentTerminalStore,
       _multisig
     );
-    evm.label(address(_jbERC20PaymentTerminal), 'JBERC20PaymentTerminal');
+    vm.label(address(_jbERC20PaymentTerminal), 'JBERC20PaymentTerminal');
   }
 
   //https://ethereum.stackexchange.com/questions/24248/how-to-calculate-an-ethereum-contracts-address-during-its-creation-using-the-so


### PR DESCRIPTION
Provide a simple whitelisting possibility, via a datasource. The whitelist is managed by the project owner. Anyone can reuse the whitelist (by adding this datasource as funding cycle datasource).

This implementation uses a mapping of whitelisted addresses, and might therefore not be able to handle large whitelist (where other solutions might be more gas efficients, Merkle tree of the addresses for instance)